### PR TITLE
Atualiza nome do usuário na página inicial após alteração no perfil

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,16 +5,38 @@ import Header from "../components/Header";
 import Carousel from "../components/Carousel";
 import NewCourses from "../components/NewCourses";
 import { courseService, Course } from "../services/courseService";
+import { userService } from "../services/userService";
 // import DebugState from "./DebugState";
 
 
 export default function Home() {
+   const [nome, setNome] = useState("");
   const [userCourses, setUserCourses] = useState<Course[]>([]);
   const [newCourses, setNewCourses] = useState<Course[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
+   useEffect(() => {
+      userService.getUser().then((user) => 
+      {
+        setNome(user.name);
+        setIsLoading
+        (false);
+      });
+    }, []);
+  
+    // Estados para edição temporária
+    const [, setEditNome] = useState("");
+  
+    // Preenche os campos de edição quando os dados carregam
+    useEffect(() => {
+      setEditNome(nome);
+      
+    }, [nome]);
+
+
   useEffect(() => {
     async function fetchCourses() {
+      
       setIsLoading(true);
       const all = await courseService.getAllCourses();
       setUserCourses(all.filter((c: Course) => c.enrolled));
@@ -46,7 +68,7 @@ export default function Home() {
     <div className="min-h-screen flex bg-[#eae5e0]">
       <Sidebar />
       <div className="flex-1 flex flex-col">
-        <Header userName="Paula" />
+        <Header userName={nome} />
         <main className="flex-1 p-8 bg-white rounded-xl shadow-sm mt-6">
           {isLoading ? (
             <div>Carregando...</div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,7 @@ export default function Home() {
       setNome(user.name);
       setLoading(false);
     });
-  }, []);
+  }, [setLoading]);
 
   // Estados para edição temporária
   const [, setEditNome] = useState("");
@@ -39,7 +39,7 @@ export default function Home() {
       setLoading(false);
     }
     fetchCourses();
-  }, []);
+  }, [setLoading]);
 
   async function onEnroll(courseId: string) {
     setLoading(true);

--- a/src/app/perfil/page.tsx
+++ b/src/app/perfil/page.tsx
@@ -11,7 +11,7 @@ export default function PerfilPage() {
   const [senha, setSenha] = useState("********");
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
+ useEffect(() => {
     userService.getUser().then((user) => {
       setNome(user.name);
       setEmail(user.email);
@@ -19,10 +19,22 @@ export default function PerfilPage() {
     });
   }, []);
 
+  // Estados para edição temporária
+  const [editNome, setEditNome] = useState("");
+  const [editEmail, setEditEmail] = useState("");
+
+  // Preenche os campos de edição quando os dados carregam
+  useEffect(() => {
+    setEditNome(nome);
+    setEditEmail(email);
+  }, [nome, email]);
+
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
     setLoading(true);
-    await userService.updateUser({ name: nome, email });
+    await userService.updateUser({ name: editNome, email: editEmail });
+    setNome(editNome);
+    setEmail(editEmail);
     setLoading(false);
     alert("Perfil salvo!");
   }
@@ -53,7 +65,7 @@ export default function PerfilPage() {
                 <p className="text-gray-700 text-sm mb-8">
                   Aqui você pode gerenciar suas informações.
                 </p>
-                <form onSubmit={handleSave} className="flex flex-col gap-8">
+                  <form onSubmit={handleSave} className="flex flex-col gap-8">
               
                   <div className="flex items-center gap-6 mb-4">
                     <div>
@@ -78,8 +90,8 @@ export default function PerfilPage() {
                     </label>
                     <input
                       className="rounded-md border border-gray-300 px-4 py-2 bg-white text-black focus:outline-none focus:ring-2 focus:ring-black"
-                      value={nome}
-                      onChange={(e) => setNome(e.target.value)}
+                      value={editNome}
+                      onChange={(e) => setEditNome(e.target.value)}
                       placeholder="Nome Completo"
                     />
                     <label className="text-sm font-medium text-black">
@@ -87,8 +99,8 @@ export default function PerfilPage() {
                     </label>
                     <input
                       className="rounded-md border border-gray-300 px-4 py-2 bg-white text-black focus:outline-none focus:ring-2 focus:ring-black"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
+                      value={editEmail}
+                      onChange={(e) => setEditEmail(e.target.value)}
                       placeholder="Email"
                       type="email"
                     />
@@ -101,6 +113,7 @@ export default function PerfilPage() {
                       onChange={(e) => setSenha(e.target.value)}
                       placeholder="Senha"
                       type="password"
+                      disabled
                     />
                   </div>
                 </form>


### PR DESCRIPTION
- Agora o nome exibido no Header da página inicial é atualizado automaticamente após o usuário alterar e salvar seu nome no perfil.
- Ajustada a lógica para garantir que a alteração só é refletida após clicar em Salvar no perfil.